### PR TITLE
Override additional DateTime methods

### DIFF
--- a/lib/DateTime.php
+++ b/lib/DateTime.php
@@ -127,49 +127,49 @@ class DateTime extends \DateTime
 	public function setDate($year, $month, $day)
 	{
 		$this->flag_dirty();
-		call_user_func_array(array($this,'parent::setDate'),func_get_args());
+		return parent::setDate($year, $month, $day);
 	}
 
 	public function setISODate($year, $week , $day=null)
 	{
 		$this->flag_dirty();
-		call_user_func_array(array($this,'parent::setISODate'),func_get_args());
+		return parent::setISODate($year, $week, $day);
 	}
 
 	public function setTime($hour, $minute, $second=null)
 	{
 		$this->flag_dirty();
-		call_user_func_array(array($this,'parent::setTime'),func_get_args());
+		return parent::setTime($hour, $minute, $second);
 	}
 
 	public function setTimestamp($unixtimestamp)
 	{
 		$this->flag_dirty();
-		call_user_func_array(array($this,'parent::setTimestamp'),func_get_args());
+		return parent::setTimestamp($unixtimestamp);
 	}
 
 	public function setTimezone(\DateTimeZone $timezone)
 	{
 		$this->flag_dirty();
-		call_user_func_array(array($this,'parent::setTimezone'),func_get_args());
+		return parent::setTimezone($timezone);
 	}
 	
 	public function modify($modify)
 	{
 		$this->flag_dirty();
-		call_user_func_array(array($this,'parent::modify'),func_get_args());
+		return parent::modify($modify);
 	}
 	
 	public function add(\DateInterval $interval)
 	{
 		$this->flag_dirty();
-		call_user_func_array(array($this,'parent::add'),func_get_args());
+		return parent::add($interval);
 	}
 
 	public function sub(\DateInterval $interval)
 	{
 		$this->flag_dirty();
-		call_user_func_array(array($this,'parent::sub'),func_get_args());
+		return parent::sub($interval);
 	}
 
 }

--- a/lib/DateTime.php
+++ b/lib/DateTime.php
@@ -147,4 +147,29 @@ class DateTime extends \DateTime
 		$this->flag_dirty();
 		call_user_func_array(array($this,'parent::setTimestamp'),func_get_args());
 	}
+
+	public function setTimezone(\DateTimeZone $timezone)
+	{
+		$this->flag_dirty();
+		call_user_func_array(array($this,'parent::setTimezone'),func_get_args());
+	}
+	
+	public function modify($modify)
+	{
+		$this->flag_dirty();
+		call_user_func_array(array($this,'parent::modify'),func_get_args());
+	}
+	
+	public function add(\DateInterval $interval)
+	{
+		$this->flag_dirty();
+		call_user_func_array(array($this,'parent::add'),func_get_args());
+	}
+
+	public function sub(\DateInterval $interval)
+	{
+		$this->flag_dirty();
+		call_user_func_array(array($this,'parent::sub'),func_get_args());
+	}
+
 }

--- a/test/DateTimeTest.php
+++ b/test/DateTimeTest.php
@@ -38,6 +38,11 @@ class DateTimeTest extends SnakeCase_PHPUnit_Framework_TestCase
 		$this->assert_dirtifies('setISODate',2001,1);
 		$this->assert_dirtifies('setTime',1,1);
 		$this->assert_dirtifies('setTimestamp',1);
+		$this->assert_dirtifies('setTimezone',1);
+		$this->assert_dirtifies('modify','+1 day');
+		$interval = new DateInterval('PT1S');
+		$this->assert_dirtifies('add',$interval);
+		$this->assert_dirtifies('sub',$interval);
 	}
 
 	public function test_set_iso_date()


### PR DESCRIPTION
The `ActiveRecord\DateTime` class does not always get flagged as dirty when it's modified. This is because the class doesn't override all of the `DateTime` methods that are capable of modifying its value. I've added overriding methods in this commit so that whenever the following are called, the value will get flagged as dirty:

`DateTime::add()`
`DateTime::sub()`
`DateTime::modify()`
`DateTime::setTimezone()`